### PR TITLE
Typo in exports?

### DIFF
--- a/drykup.coffee
+++ b/drykup.coffee
@@ -232,5 +232,5 @@ drykup = (opts) ->
         	dk[tagName] = (args...) -> dk.selfClosingTag tagName, args
 	dk
 
-if module.exports then module.exports = drykup else windows.drykup = drykup
+if module.exports then module.exports = drykup else window.drykup = drykup
 


### PR DESCRIPTION
Should export to `window.drykup`
